### PR TITLE
Add local xAOD code generator

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -70,7 +70,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[test]
+          pip install .[test,xAOD]
 
       - name: Run tests with coverage
         run: |

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -49,7 +49,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install .[test]
+          pip install .[test,xAOD]
 
       - name: Run tests
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -126,3 +126,6 @@ dmypy.json
 
 # Pyre type checker
 .pyre/
+
+# Other things
+servicex.yaml

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -9,6 +9,7 @@
         "globus",
         "pydantic",
         "pyproject",
+        "qastle",
         "sdist",
         "sslhep",
         "toolbelt",

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ The science image code will pick up the location of the 509 cert.
 
 ## Usage
 
-**DRAFT**
+This text is a **DRAFT**
 
 To use this, example code is as follows:
 

--- a/README.md
+++ b/README.md
@@ -5,11 +5,21 @@ mostly geared toward running for debugging and testing.
 
 ## Installation
 
-Install this as a library in your virtual environment with `pip install servicex-local`.
+Install this as a library in your virtual environment with:
 
-Use the `voms_proxy_init` command to init your proxy. It will need the location of your `~/.globus` directory.
+* `pip install servicex-local` for all the Docker based codegen and science container access.
+* `pip install servicex-local[xAOD]` to get a local xAOD code generator (and the required dependencies) along with the docker based code.
+
+Some science images requires a x509 certificate to run. You'll need to get the `x509up` into your `/tmp` area. If you don't have the tools installed locally, do the following:
+
+1. Make sure in your `~/.globus` directory (on whatever OS you are no) contains the `usercert.pem` and `userkey.pem` files
+1. Use the `voms_proxy_init` to initialize against the `atlas` voms.
+
+The science image code will pick up the location of the 509 cert.
 
 ## Usage
+
+**DRAFT**
 
 To use this, example code is as follows:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,8 @@ docs = [
     "sphinx-tabs>=3.4.5",
     "sphinx-copybutton>=0.5.2",
 ]
-develop = ["servicex[test,docs]"]
+xAOD = ["func_adl_xAOD"]
+develop = ["servicex[test,docs,xAOD]"]
 
 [project.scripts]
 voms_proxy_init = "servicex_local.create_x509:main"
@@ -64,10 +65,16 @@ voms_proxy_init = "servicex_local.create_x509:main"
 [tool.hatch.build.targets.sdist]
 # hatchling always includes:
 # pyproject.toml, .gitignore, any README, any LICENSE, AUTHORS
-include = ["/servicex_local/"]
+include = [
+    "/servicex_local/",
+    "/servicex_local/templates/transform_single_file.sh"
+]
 
 [tool.hatch.build.targets.wheel]
 packages = ["servicex_local"]
+include = [
+    "/servicex_local/templates/transform_single_file.sh"
+]
 
 [tool.coverage.run]
 dynamic_context = "test_function"

--- a/servicex_local/templates/transform_single_file.sh
+++ b/servicex_local/templates/transform_single_file.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set +e
+
+# If transformer has already run then we don't need to compile
+if [ ! -d /home/atlas/rel ]; then
+  echo "Compile"
+  bash /generated/runner.sh -c
+  if [ $? != 0 ]; then
+    echo "Compile step failed"
+    exit 1
+  fi
+fi
+
+echo "Transform a file $1 -> $2"
+bash /generated/runner.sh -r -d "$1" -o "$2"
+if [ $? != 0 ]; then
+  echo "Transform step failed"
+  exit 1
+fi

--- a/tests/test_adaptor.py
+++ b/tests/test_adaptor.py
@@ -35,6 +35,6 @@ def test_adaptor_xaod_wsl2():
             }
         ]
     }
-    files = deliver(spec, servicex_name="servicex-uc-af")  # , sx_adaptor=adaptor)
+    files = deliver(spec, servicex_name="servicex-uc-af", sx_adaptor=adaptor)
     assert files is not None, "No files returned from deliver! Internal error"
     assert False

--- a/tests/test_adaptor.py
+++ b/tests/test_adaptor.py
@@ -1,6 +1,7 @@
 import pytest
 from servicex_local import WSL2ScienceImage, LocalXAODCodegen, SXLocalAdaptor
 from servicex import query as q, deliver, dataset
+import logging
 
 
 @pytest.mark.skip(reason="This integration test is not ready to run")
@@ -8,6 +9,8 @@ def test_adaptor_xaod_wsl2():
     codegen = LocalXAODCodegen()
     science_runner = WSL2ScienceImage("atlas_al9", "22.2.107")
     adaptor = SXLocalAdaptor(codegen, science_runner)
+
+    logging.basicConfig(level=logging.DEBUG)
 
     # The simple query, take straight from the example in the documentation.
     query = q.FuncADL_ATLASr22()  # type: ignore
@@ -32,5 +35,6 @@ def test_adaptor_xaod_wsl2():
             }
         ]
     }
-    files = deliver(spec, servicex_name="servicex-uc-af", sx_adaptor=adaptor)
+    files = deliver(spec, servicex_name="servicex-uc-af")  # , sx_adaptor=adaptor)
     assert files is not None, "No files returned from deliver! Internal error"
+    assert False

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -2,6 +2,8 @@ import pytest
 from servicex_local import DockerCodegen
 from pathlib import Path
 
+from servicex_local import LocalXAODCodegen
+
 
 @pytest.mark.skip("This test requires docker to be installed")
 def test_docker_codegen_xaod(tmp_path):
@@ -22,3 +24,19 @@ def test_docker_codegen_xaod(tmp_path):
     # Check there is only one file in the directory
     all_files = list(Path(r).iterdir())
     assert len(all_files) == 3, f"Expected 1 file, found {len(all_files)}"
+
+
+def test_local_func_xAOD(tmp_path):
+
+    query = (
+        "(call Select (call Select (call EventDataset) (lambda (list e) "
+        "(call (attr e 'Jets') 'AnalysisJets'))) (lambda (list jets) (dict "
+        " (list 'pt' 'eta') (list (call (attr jets 'Select') (lambda (list j) "
+        "(call (attr j 'pt')))) (call (attr jets 'Select') (lambda "
+        "(list j) (call (attr j 'eta'))))))))"
+    )
+
+    codegen = LocalXAODCodegen()
+    r = codegen.gen_code(query, tmp_path)
+    all_files = list(Path(r).iterdir())
+    assert len(all_files) == 6, f"Expected 1 file, found {len(all_files)}"


### PR DESCRIPTION
* Add a `LocalXAODCodegen` which allows one to run the xAOD code gen locally - this is primarily for debugging purposes.
* Improve `README.md` with references about how to install, among other things.