### PR TITLE
Make sure `logging` is used to dump messages when running in WSL2

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,7 @@
         "asyncio",
         "atlaslocalgroupdisk",
         "autodoc",
+        "caplog",
         "codegen",
         "copybutton",
         "cvmfs",

--- a/servicex_local/science_images.py
+++ b/servicex_local/science_images.py
@@ -23,6 +23,9 @@ def run_command_with_logging(command: List[str]) -> None:
     stdout_lines = []
     stderr_lines = []
 
+    assert process.stdout is not None
+    assert process.stderr is not None
+
     for stdout_line in iter(process.stdout.readline, ""):
         stripped_line = stdout_line.strip()
         logger.debug(stripped_line)

--- a/servicex_local/science_images.py
+++ b/servicex_local/science_images.py
@@ -37,11 +37,21 @@ def run_command_with_logging(command: List[str]) -> None:
     return_code = process.wait()
 
     if return_code != 0:
+        # TODO: Once we are done with 3.11, get rid of newline. Problem is
+        #       we can't have a \n in an f-string for the older versions of python.
+        newline = "\n"
         raise RuntimeError(
-            "Command failed with return code {return_code}" "\n"
-            f"command: {' '.join(command)}" "\n"
-            "stdout:" "\n" f"{'\n'.join(stdout_lines)}""\n"
-            "stderr:" "\n" f"{'\n'.join(stderr_lines)}"
+            f"Command failed with return code {return_code}"
+            + newline
+            + f"command: {' '.join(command)}"
+            + newline
+            + "stdout:"
+            + newline
+            + f"{'-'.join(stdout_lines)}"
+            + newline
+            + "stderr:"
+            + newline
+            + f"{'-'.join(stderr_lines)}"
         )
 
 

--- a/servicex_local/science_images.py
+++ b/servicex_local/science_images.py
@@ -38,9 +38,10 @@ def run_command_with_logging(command: List[str]) -> None:
 
     if return_code != 0:
         raise RuntimeError(
-            f"Command failed with return code {return_code}\n"
-            f"stdout:\n{'\n'.join(stdout_lines)}\n"
-            f"stderr:\n{'\n'.join(stderr_lines)}"
+            "Command failed with return code {return_code}" "\n"
+            f"command: {' '.join(command)}" "\n"
+            "stdout:" "\n" f"{'\n'.join(stdout_lines)}""\n"
+            "stderr:" "\n" f"{'\n'.join(stderr_lines)}"
         )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,3 @@
+def pytest_addoption(parser):
+    parser.addoption("--wsl2", action="store_true", help="run WSL2 tests")
+    parser.addoption("--docker", action="store_true", help="run Docker tests")

--- a/tests/genfiles_raw/query2_xaod/runner.sh
+++ b/tests/genfiles_raw/query2_xaod/runner.sh
@@ -44,7 +44,11 @@ if [ $# != 0 ]; then
 fi
 
 # Setup and config
-source /home/atlas/release_setup.sh
+if [ -f /home/atlas/release_setup.sh ]; then
+   source /home/atlas/release_setup.sh
+else
+   echo "/home/atlas/release_setup.sh not found. Skipping."
+fi
 
 # Remember where we are and the script location.
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"

--- a/tests/test_science_images.py
+++ b/tests/test_science_images.py
@@ -64,3 +64,27 @@ def test_wsl2_science(tmp_path, caplog):
     outputs[0].exists()
     assert len(caplog.records) == 0
     assert caplog.text == ""
+
+
+# @pytest.mark.skip(reason="This test needs wsl2 to be installed")
+def test_wsl2_science_logging(tmp_path, caplog):
+    """Test a xAOD transform on a WSL2 atlas distribution
+    This test takes about 100 seconds to run on a connection
+    that is reasonable (at home). Takes 300 to 400 seconds if
+    cvmfs is cold.
+    """
+    with caplog.at_level(logging.DEBUG):
+        wsl2 = WSL2ScienceImage("atlas_al9", "25.2.12")
+        outputs = wsl2.transform(
+            Path("tests/genfiles_raw/query2_xaod"),
+            [
+                "root://eospublic.cern.ch//eos/opendata/atlas/rucio/mc20_13TeV/"
+                "DAOD_PHYSLITE.37622528._000013.pool.root.1"
+            ],
+            tmp_path / "output",
+            "root-file",
+        )
+
+    assert len(outputs) == 1
+    outputs[0].exists()
+    assert "release_setup.sh" in caplog.text

--- a/tests/test_science_images.py
+++ b/tests/test_science_images.py
@@ -41,7 +41,7 @@ def test_docker_science(tmp_path):
     assert output_files[0].exists()
 
 
-# @pytest.mark.skip(reason="This test needs wsl2 to be installed")
+@pytest.mark.skip(reason="This test needs wsl2 to be installed")
 def test_wsl2_science(tmp_path, caplog):
     """Test a xAOD transform on a WSL2 atlas distribution
     This test takes about 100 seconds to run on a connection
@@ -66,7 +66,7 @@ def test_wsl2_science(tmp_path, caplog):
     assert caplog.text == ""
 
 
-# @pytest.mark.skip(reason="This test needs wsl2 to be installed")
+@pytest.mark.skip(reason="This test needs wsl2 to be installed")
 def test_wsl2_science_logging(tmp_path, caplog):
     """Test a xAOD transform on a WSL2 atlas distribution
     This test takes about 100 seconds to run on a connection
@@ -88,3 +88,26 @@ def test_wsl2_science_logging(tmp_path, caplog):
     assert len(outputs) == 1
     outputs[0].exists()
     assert "release_setup.sh" in caplog.text
+
+
+@pytest.mark.skip(reason="This test needs wsl2 to be installed")
+def test_wsl2_science_error(tmp_path):
+    """Test a xAOD transform on a WSL2 atlas distribution
+    This test takes about 100 seconds to run on a connection
+    that is reasonable (at home). Takes 300 to 400 seconds if
+    cvmfs is cold.
+    """
+    wsl2 = WSL2ScienceImage("atlas_al9", "25.2.12")
+    with pytest.raises(
+        RuntimeError,
+        match="failed to open file root://fork.me.now//eos/opendata/atlas/rucio/mc20_13TeV/DAOD_PHYSLITE.37622528._000013.pool.root.1\nDirectInputModule",
+    ):
+        wsl2.transform(
+            Path("tests/genfiles_raw/query2_xaod"),
+            [
+                "root://fork.me.now//eos/opendata/atlas/rucio/mc20_13TeV/"
+                "DAOD_PHYSLITE.37622528._000013.pool.root.1"
+            ],
+            tmp_path / "output",
+            "root-file",
+        )

--- a/tests/test_science_images.py
+++ b/tests/test_science_images.py
@@ -103,7 +103,10 @@ def test_wsl2_science_error(tmp_path, request):
     wsl2 = WSL2ScienceImage("atlas_al9", "25.2.12")
     with pytest.raises(
         RuntimeError,
-        match="failed to open file root://fork.me.now//eos/opendata/atlas/rucio/mc20_13TeV/DAOD_PHYSLITE.37622528._000013.pool.root.1\nDirectInputModule",
+        match=(
+            "failed to open file root://fork.me.now//eos/opendata/atlas/rucio/mc20_13TeV"
+            "/DAOD_PHYSLITE.37622528._000013.pool.root.1\nDirectInputModule"
+        ),
     ):
         wsl2.transform(
             Path("tests/genfiles_raw/query2_xaod"),

--- a/tests/test_science_images.py
+++ b/tests/test_science_images.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import shutil
 from pathlib import Path
@@ -40,24 +41,26 @@ def test_docker_science(tmp_path):
     assert output_files[0].exists()
 
 
-@pytest.mark.skip(reason="This test needs wsl2 to be installed")
-def test_wsl2_science(tmp_path):
+# @pytest.mark.skip(reason="This test needs wsl2 to be installed")
+def test_wsl2_science(tmp_path, caplog):
     """Test a xAOD transform on a WSL2 atlas distribution
     This test takes about 100 seconds to run on a connection
     that is reasonable (at home). Takes 300 to 400 seconds if
     cvmfs is cold.
     """
-
-    wsl2 = WSL2ScienceImage("atlas_al9", "25.2.12")
-    outputs = wsl2.transform(
-        Path("tests/genfiles_raw/query2_xaod"),
-        [
-            "root://eospublic.cern.ch//eos/opendata/atlas/rucio/mc20_13TeV/"
-            "DAOD_PHYSLITE.37622528._000013.pool.root.1"
-        ],
-        tmp_path / "output",
-        "root-file",
-    )
+    with caplog.at_level(logging.WARNING):
+        wsl2 = WSL2ScienceImage("atlas_al9", "25.2.12")
+        outputs = wsl2.transform(
+            Path("tests/genfiles_raw/query2_xaod"),
+            [
+                "root://eospublic.cern.ch//eos/opendata/atlas/rucio/mc20_13TeV/"
+                "DAOD_PHYSLITE.37622528._000013.pool.root.1"
+            ],
+            tmp_path / "output",
+            "root-file",
+        )
 
     assert len(outputs) == 1
     outputs[0].exists()
+    assert len(caplog.records) == 0
+    assert caplog.text == ""

--- a/tests/test_science_images.py
+++ b/tests/test_science_images.py
@@ -8,11 +8,10 @@ import pytest
 from servicex_local.science_images import DockerScienceImage, WSL2ScienceImage
 
 
-@pytest.mark.skip(
-    reason="This test needs docker to be installed and grid cert is needed"
-)
-def test_docker_science(tmp_path):
-    "Run a simple test of the docker science image"
+def test_docker_science(tmp_path, request):
+    "Test against a docker science image - integrated (uses docker)"
+    if not request.config.getoption("--docker"):
+        pytest.skip("Use the --wsl2 pytest flag to run this test")
 
     # We need the files we'll use as input.
     generated_file_directory = tmp_path / "input"
@@ -41,13 +40,15 @@ def test_docker_science(tmp_path):
     assert output_files[0].exists()
 
 
-@pytest.mark.skip(reason="This test needs wsl2 to be installed")
-def test_wsl2_science(tmp_path, caplog):
+def test_wsl2_science(tmp_path, caplog, request):
     """Test a xAOD transform on a WSL2 atlas distribution
     This test takes about 100 seconds to run on a connection
     that is reasonable (at home). Takes 300 to 400 seconds if
     cvmfs is cold.
     """
+    if not request.config.getoption("--wsl2"):
+        pytest.skip("Use the --wsl2 pytest flag to run this test")
+
     with caplog.at_level(logging.WARNING):
         wsl2 = WSL2ScienceImage("atlas_al9", "25.2.12")
         outputs = wsl2.transform(
@@ -66,13 +67,14 @@ def test_wsl2_science(tmp_path, caplog):
     assert caplog.text == ""
 
 
-@pytest.mark.skip(reason="This test needs wsl2 to be installed")
-def test_wsl2_science_logging(tmp_path, caplog):
+def test_wsl2_science_logging(tmp_path, caplog, request):
     """Test a xAOD transform on a WSL2 atlas distribution
     This test takes about 100 seconds to run on a connection
     that is reasonable (at home). Takes 300 to 400 seconds if
     cvmfs is cold.
     """
+    if not request.config.getoption("--wsl2"):
+        pytest.skip("Use the --wsl2 pytest flag to run this test")
     with caplog.at_level(logging.DEBUG):
         wsl2 = WSL2ScienceImage("atlas_al9", "25.2.12")
         outputs = wsl2.transform(
@@ -90,13 +92,14 @@ def test_wsl2_science_logging(tmp_path, caplog):
     assert "release_setup.sh" in caplog.text
 
 
-@pytest.mark.skip(reason="This test needs wsl2 to be installed")
-def test_wsl2_science_error(tmp_path):
+def test_wsl2_science_error(tmp_path, request):
     """Test a xAOD transform on a WSL2 atlas distribution
     This test takes about 100 seconds to run on a connection
     that is reasonable (at home). Takes 300 to 400 seconds if
     cvmfs is cold.
     """
+    if not request.config.getoption("--wsl2"):
+        pytest.skip("Use the --wsl2 pytest flag to run this test")
     wsl2 = WSL2ScienceImage("atlas_al9", "25.2.12")
     with pytest.raises(
         RuntimeError,


### PR DESCRIPTION
* Add logging to WSL2 science running
* Add pytest `--wsl2` and `--docker` options to be able to run those tests easily.
* Add tests to look for output and also to make sure crashes are dealt with correctly.

wsl2 messages are not properly printed out 
Fixes #19
Fixes #18
Fixes #12