### PR TITLE
Use `transformer_capabilities` to invoke the science payloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,3 +131,4 @@ dmypy.json
 servicex.yaml
 
 wsl_transform_script.sh
+kick_off.py

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ The science image code will pick up the location of the 509 cert.
 
 ## Usage
 
+### Certificates
+
+This will do its best to track `x509` certs. If a file called `x509up` is located in your temp directory (including on windows), that will be copied into the `docker` image or other places to be used.
+
+### Example Code
+
 This text is a **DRAFT**
 
 To use this, example code is as follows:

--- a/servicex_local/science_images.py
+++ b/servicex_local/science_images.py
@@ -160,9 +160,11 @@ with open("{wsl_generated_files_dir}/transformer_capabilities.json") as f:
     info = json.load(f)
 file_to_run = info["command"]
 if info["language"] == "python":
-    os.system("python3 {wsl_generated_files_dir}/" + file_to_run + " {wsl_input_file} {wsl_output_directory}/{input_path_name} {output_format}")
+    os.system("python3 {wsl_generated_files_dir}/" + file_to_run + " {wsl_input_file} "
+        + "{wsl_output_directory}/{input_path_name} {output_format}")
 elif info["language"] == "bash":
-    os.system("bash {wsl_generated_files_dir}/" + file_to_run + " {wsl_input_file} {wsl_output_directory}/{input_path_name} {output_format}")
+    os.system("bash {wsl_generated_files_dir}/" + file_to_run
+        + " {wsl_input_file} {wsl_output_directory}/{input_path_name} {output_format}")
 else:
     raise ValueError("Unsupported language: " + info["language"])
 """

--- a/servicex_local/science_images.py
+++ b/servicex_local/science_images.py
@@ -144,6 +144,31 @@ class WSL2ScienceImage(BaseScienceImage):
                 wsl_input_file = self._convert_to_wsl_path(input_path)
                 input_path_name = input_path.name
 
+            # Create the script to parse the capabilities file.
+            file_runner = f"""#!/bin/python
+import json
+import os
+import sys
+from pathlib import Path
+
+x509up_path = Path("/tmp/grid-security/x509up")
+if x509up_path.exists():
+    os.chmod(x509up_path, 0o600)
+    os.system("ls -l /tmp/grid-security/x509up")
+
+with open("{wsl_generated_files_dir}/transformer_capabilities.json") as f:
+    info = json.load(f)
+file_to_run = info["command"]
+if info["language"] == "python":
+    os.system("python3 {wsl_generated_files_dir}/" + file_to_run + " {wsl_input_file} {wsl_output_directory}/{input_path_name} {output_format}")
+elif info["language"] == "bash":
+    os.system("bash {wsl_generated_files_dir}/" + file_to_run + " {wsl_input_file} {wsl_output_directory}/{input_path_name} {output_format}")
+else:
+    raise ValueError("Unsupported language: " + info["language"])
+"""
+            with open(generated_files_dir / "kick_off.py", "w", newline="\n") as f:
+                f.write(file_runner)
+
             # Create the WSL script content
             wsl_script_content = f"""#!/bin/bash
 tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
@@ -152,13 +177,14 @@ cd $tmp_dir
 # source /etc/profile.d/startup-atlas.sh
 setupATLAS
 asetup AnalysisBase,{self._release},here
-source {wsl_generated_files_dir}/transform_single_file.sh {wsl_input_file} {wsl_output_directory}/{input_path_name}  # noqa
+python {wsl_generated_files_dir}/kick_off.py
 """
 
             # Write the script to a temporary file
             script_path = generated_files_dir / "wsl_transform_script.sh"
             with open(script_path, "w", newline="\n") as script_file:
                 script_file.write(wsl_script_content)
+
             # Convert script_path to a WSL accessible path
             wsl_script_path = self._convert_to_wsl_path(script_path)
 
@@ -224,8 +250,7 @@ class DockerScienceImage(BaseScienceImage):
 
             # Create the file that will actually do the work. We need to look at the transformer
             # capabilities json file to figure it out.
-            file_runner = """
-#!/bin/python
+            file_runner = """#!/bin/python
 import json
 import os
 import sys

--- a/servicex_local/science_images.py
+++ b/servicex_local/science_images.py
@@ -206,7 +206,7 @@ class DockerScienceImage(BaseScienceImage):
             List[Path]: The paths to the output files
         """
         output_paths = []
-        x509up_path = Path("/tmp/x509up")
+        x509up_path = Path(os.getenv("TEMP", "/tmp")) / "x509up"
         if x509up_path.exists():
             x509up_volume = ["-v", f"{x509up_path}:/tmp/grid-security/x509up"]
         else:
@@ -222,6 +222,36 @@ class DockerScienceImage(BaseScienceImage):
 
             output_name = Path(input_file).name
 
+            # Create the file that will actually do the work. We need to look at the transformer
+            # capabilities json file to figure it out.
+            file_runner = """
+#!/bin/python
+import json
+import os
+import sys
+from pathlib import Path
+
+x509up_path = Path("/tmp/grid-security/x509up")
+if x509up_path.exists():
+    os.chmod(x509up_path, 0o600)
+    os.system("ls -l /tmp/grid-security/x509up")
+
+with open("/generated/transformer_capabilities.json") as f:
+    info = json.load(f)
+file_to_run = info["command"]
+arg1 = sys.argv[1]
+arg2 = sys.argv[2]
+arg3 = sys.argv[3]
+if info["language"] == "python":
+    os.system(f"python3 {file_to_run} {arg1} {arg2} {arg3}")
+elif info["language"] == "bash":
+    os.system(f"bash {file_to_run} {arg1} {arg2} {arg3}")
+else:
+    raise ValueError(f"Unsupported language: {info["language"]}")
+"""
+            with open(generated_files_dir / "kick_off.py", "w") as f:
+                f.write(file_runner)
+
             try:
                 command = [
                     "docker",
@@ -235,8 +265,8 @@ class DockerScienceImage(BaseScienceImage):
                     f"{output_directory}:/servicex/output",
                     *x509up_volume,
                     self.image_name,
-                    "bash",
-                    "/generated/transform_single_file.sh",
+                    "python",
+                    "/generated/kick_off.py",
                     input_file,
                     f"/servicex/output/{output_name}",
                     output_format,

--- a/tests/genfiles_raw/query2_xaod/transformer_capabilities.json
+++ b/tests/genfiles_raw/query2_xaod/transformer_capabilities.json
@@ -1,0 +1,11 @@
+{
+  "name": "FuncADL based C++ transformer",
+  "description": "Two different transformers. One for ATLAS reads xAOD files. A second transformer reads CMS Run 1 AOD files",
+  "limitations": "Would be good to note what isn't implemented",
+  "file-formats": [
+    "root"
+  ],
+  "stats-parser": "AODStats",
+  "language": "bash",
+  "command": "/generated/transform_single_file.sh"
+}

--- a/tests/test_science_images.py
+++ b/tests/test_science_images.py
@@ -12,8 +12,8 @@ def test_docker_science(tmp_path, request):
     """Test against a docker science image - integrated (uses docker)
     WARNING: This expects to find the x509 cert!!!
     """
-    # if not request.config.getoption("--docker"):
-    #     pytest.skip("Use the --wsl2 pytest flag to run this test")
+    if not request.config.getoption("--docker"):
+        pytest.skip("Use the --wsl2 pytest flag to run this test")
 
     # We need the files we'll use as input.
     generated_file_directory = tmp_path / "input"

--- a/tests/test_science_images.py
+++ b/tests/test_science_images.py
@@ -9,9 +9,11 @@ from servicex_local.science_images import DockerScienceImage, WSL2ScienceImage
 
 
 def test_docker_science(tmp_path, request):
-    "Test against a docker science image - integrated (uses docker)"
-    if not request.config.getoption("--docker"):
-        pytest.skip("Use the --wsl2 pytest flag to run this test")
+    """Test against a docker science image - integrated (uses docker)
+    WARNING: This expects to find the x509 cert!!!
+    """
+    # if not request.config.getoption("--docker"):
+    #     pytest.skip("Use the --wsl2 pytest flag to run this test")
 
     # We need the files we'll use as input.
     generated_file_directory = tmp_path / "input"
@@ -32,6 +34,7 @@ def test_docker_science(tmp_path, request):
         "rucio/user/mgeyik/e7/ee/user.mgeyik.30182995._000093.out.root"
     ]
     docker = DockerScienceImage("sslhep/servicex_func_adl_uproot_transformer:uproot5")
+    logging.basicConfig(level=logging.DEBUG)
     output_files = docker.transform(
         generated_file_directory, input_files, output_file_directory, "root-file"
     )


### PR DESCRIPTION
* Update how it loads up the x509 cert to run a ltitle better on windows, if you copy the cert to the default place.
* Docker now uses the `transformer_capabilities.json` to invoke the transformer

This PR revealed the testing infrastructure was actually quite broken. A PR based on #26 will fix it. But this code may not be 100% after this.

Fixes #9
