### PR TITLE
Filter and log messages with WARNING and ERROR in them as WARNING level.

### DIFF
--- a/servicex_local/science_images.py
+++ b/servicex_local/science_images.py
@@ -28,11 +28,14 @@ def run_command_with_logging(command: List[str]) -> None:
 
     for stdout_line in iter(process.stdout.readline, ""):
         stripped_line = stdout_line.strip()
-        logger.debug(stripped_line)
         stdout_lines.append(stripped_line)
+        if "error" in stripped_line.lower() or "warning" in stripped_line.lower():
+            logger.warning(stripped_line)
+        else:
+            logger.debug(stripped_line)
     for stderr_line in iter(process.stderr.readline, ""):
         stripped_line = stderr_line.strip()
-        logger.debug(stripped_line)
+        logger.warning(stripped_line)
         stderr_lines.append(stripped_line)
 
     process.stdout.close()

--- a/tests/genfiles_raw/query7_logging_warnings/transform_a_file.py
+++ b/tests/genfiles_raw/query7_logging_warnings/transform_a_file.py
@@ -1,0 +1,18 @@
+import sys
+
+print("WARNING: this is log line 1")
+print("ERROR: this is log line 2")
+
+# Check if the correct number of arguments is provided
+if len(sys.argv) != 4:
+    print("Usage: {} <input_file> <output_file> <output_format>".format(sys.argv[0]))
+    sys.exit(1)
+
+# Assign arguments to variables
+input_file = sys.argv[1]
+output_file = sys.argv[2]
+output_format = sys.argv[3]
+
+# Touch the output file so it is created.
+with open(output_file, "w") as f:
+    pass

--- a/tests/genfiles_raw/query7_logging_warnings/transformer_capabilities.json
+++ b/tests/genfiles_raw/query7_logging_warnings/transformer_capabilities.json
@@ -1,0 +1,11 @@
+{
+  "name": "Uproot transformer using native uproot arguments",
+  "description": "Extracts data from flat ntuple style root files.",
+  "limitations": "Would be good to note what isn't implemented",
+  "file-formats": [
+    "parquet"
+  ],
+  "stats-parser": "RawUprootStats",
+  "language": "python",
+  "command": "/generated/transform_a_file.py"
+}

--- a/tests/test_science_images.py
+++ b/tests/test_science_images.py
@@ -197,7 +197,7 @@ def test_wsl2_science_logging(tmp_path, caplog, request):
 
 
 def test_docker_science_logging(tmp_path, caplog, request):
-    """Run a simple wsl2 transform and make sure we pick up log messages."""
+    """Run a simple docker transform and make sure we pick up log messages."""
     if not request.config.getoption("--docker"):
         pytest.skip("Use the --wsl2 pytest flag to run this test")
 
@@ -219,6 +219,32 @@ def test_docker_science_logging(tmp_path, caplog, request):
         )
 
     assert "this is log line 2" in caplog.text
+
+
+def test_docker_science_log_warnings(tmp_path, caplog, request):
+    """Run a simple docker transform and make sure we pick up warning or error log messages."""
+    if not request.config.getoption("--docker"):
+        pytest.skip("Use the --wsl2 pytest flag to run this test")
+
+    generated_file_directory, actual_input_files, output_file_directory = (
+        prepare_input_files(
+            tmp_path, "tests/genfiles_raw/query7_logging_warnings", ["file1.root"]
+        )
+    )
+
+    with caplog.at_level(logging.WARNING):
+        docker = DockerScienceImage(
+            "sslhep/servicex_func_adl_uproot_transformer:uproot5"
+        )
+        docker.transform(
+            generated_file_directory,
+            actual_input_files,
+            output_file_directory,
+            "root-file",
+        )
+
+    assert "this is log line 2" in caplog.text
+    assert "this is log line 1" in caplog.text
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
If errors coming back from a run contain the word ERROR or WARNING, print them the logger. 
Fixes #29