### PR TITLE
Add transformer_capabilities as needed

### DIFF
--- a/servicex_local/codegen.py
+++ b/servicex_local/codegen.py
@@ -56,6 +56,8 @@ class LocalXAODCodegen(SXCodeGen):
         Args:
             query (str): The quastle/ query for an xAOD file.
             directory (Path): Where the output files should be written.
+            transformer_capabilities_file (Optional[Path]): This argument is ignored
+                for this code generator (and the proper one is used).
 
         Returns:
             Path: The directory where the path should be written

--- a/servicex_local/codegen.py
+++ b/servicex_local/codegen.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
 from io import BytesIO
+from typing import Optional
 from zipfile import ZipFile
 from requests_toolbelt.multipart import decoder
 from pathlib import Path
@@ -16,13 +17,20 @@ class SXCodeGen(ABC):
         pass
 
     @abstractmethod
-    def gen_code(self, query: str, directory: Path) -> Path:
+    def gen_code(
+        self,
+        query: str,
+        directory: Path,
+        transformer_capabilities_file: Optional[Path] = None,
+    ) -> Path:
         """Generate code based on the query and save all files to the
         requested directory.
 
         Args:
             query: The query string to generate code for.
             directory: The path to the directory where the code should be saved.
+            transformer_capabilities_file: The path to the transformer capabilities file.
+                If None, no file is used.
 
         Returns:
             Path: The path to the directory where the code was saved.
@@ -37,7 +45,12 @@ class LocalXAODCodegen(SXCodeGen):
         """
         pass
 
-    def gen_code(self, query: str, directory: Path) -> Path:
+    def gen_code(
+        self,
+        query: str,
+        directory: Path,
+        transformer_capabilities_file: Optional[Path] = None,
+    ) -> Path:
         """Generate the code and return a path to the directory where the code is stored.
 
         Args:
@@ -70,6 +83,10 @@ class LocalXAODCodegen(SXCodeGen):
         # Copy the template file to the directory
         template_file = Path(__file__).parent / "templates" / "transform_single_file.sh"
         shutil.copy(template_file, directory)
+        transformer_file = (
+            Path(__file__).parent / "templates" / "transformer_capabilities_xaod.json"
+        )
+        shutil.copy(transformer_file, directory / "transformer_capabilities.json")
 
         return directory
 
@@ -84,7 +101,12 @@ class DockerCodegen(SXCodeGen):
         """
         self.image_name = image_name
 
-    def gen_code(self, query: str, directory: Path) -> Path:
+    def gen_code(
+        self,
+        query: str,
+        directory: Path,
+        transformer_capabilities_file: Optional[Path] = None,
+    ) -> Path:
         """Run the code generator docker image, and save the results
         to the given directory.
 
@@ -94,6 +116,7 @@ class DockerCodegen(SXCodeGen):
         Args:
             query (str): The `quastle` (or other format) query.
             directory (Path): Where the output files should be written.
+            transformer_capabilities_file (Optional[Path]): The path to the transformer
 
         Returns:
             Path: compressed file containing all the code required.
@@ -146,6 +169,13 @@ class DockerCodegen(SXCodeGen):
         if not directory.exists():
             directory.mkdir(parents=True)
         zipfile.extractall(directory)
+
+        # Copy over the transformer capabilities file if it was provided.
+        if transformer_capabilities_file is not None:
+            shutil.copy(
+                transformer_capabilities_file,
+                directory / "transformer_capabilities.json",
+            )
 
         # The request should come back as a zip file. We now unpack that.
         return directory

--- a/servicex_local/templates/transformer_capabilities_xaod.json
+++ b/servicex_local/templates/transformer_capabilities_xaod.json
@@ -1,0 +1,11 @@
+{
+    "name": "FuncADL based C++ transformer",
+    "description": "Two different transformers. One for ATLAS reads xAOD files. A second transformer reads CMS Run 1 AOD files",
+    "limitations": "Would be good to note what isn't implemented",
+    "file-formats": [
+        "root"
+    ],
+    "stats-parser": "AODStats",
+    "language": "bash",
+    "command": "/generated/transform_single_file.sh"
+}

--- a/tests/test_codegen.py
+++ b/tests/test_codegen.py
@@ -5,25 +5,33 @@ from pathlib import Path
 from servicex_local import LocalXAODCodegen
 
 
-@pytest.mark.skip("This test requires docker to be installed")
-def test_docker_codegen_xaod(tmp_path):
+def test_docker_codegen_xaod(tmp_path, request):
     "Do a basic func_adl uproot code generation from an official docker image"
+    if not request.config.getoption("--docker"):
+        pytest.skip("Use the --wsl2 pytest flag to run this test")
+
+    # Create a dummy output json file for capabilities.
+    output_location = tmp_path / "codegen_output"
+    output_location.mkdir(parents=True, exist_ok=True)
+    transform_file = tmp_path / "my_capabilities.json"
+    transform_file.write_text("{}")
 
     # Run the code generator.
     codegen = DockerCodegen("sslhep/servicex_code_gen_raw_uproot:v1.5.4")
     query = '[{"treename": {"nominal": "modified"}, "filter_name": ["lbn"]}]'
-    r = codegen.gen_code(query, tmp_path)
+    r = codegen.gen_code(query, output_location, transform_file)
 
     # Check the output makes sense!
-    assert r == tmp_path
+    assert r == output_location
 
     # Check there is exactly one Python file in the directory
     py_files = list(Path(r).glob("*.py"))
-    assert len(py_files) == 2, f"Expected 1 Python file, found {len(py_files)}"
+    assert len(py_files) == 2, f"Expected 2 Python file, found {len(py_files)}"
 
     # Check there is only one file in the directory
     all_files = list(Path(r).iterdir())
-    assert len(all_files) == 3, f"Expected 1 file, found {len(all_files)}"
+    assert len(all_files) == 3, f"Expected 3 files, found {len(all_files)}"
+    assert "transformer_capabilities.json" in [a.name for a in all_files]
 
 
 def test_local_func_xAOD(tmp_path):
@@ -39,5 +47,9 @@ def test_local_func_xAOD(tmp_path):
     codegen = LocalXAODCodegen()
     r = codegen.gen_code(query, tmp_path)
     all_files = list(Path(r).iterdir())
-    assert len(all_files) == 6, f"Expected 1 file, found {len(all_files)}"
     assert "runner.sh" in [a.name for a in all_files], "Expected runner.sh in directory"
+
+    # Make sure the transformation capabilities file is there.
+    assert (Path(r) / "transformer_capabilities.json").exists()
+
+    assert len(all_files) == 7, f"Expected 7 file, found {len(all_files)}"


### PR DESCRIPTION
A `transformer_capabilities.json` file is required to run a science image.

* Add ability for docker code generators to add the `transformer_capabilities.json`
* Add default one for the xAOD local code generator.

Fixes #31