### PR TITLE
Use login shell

### DIFF
--- a/servicex_local/templates/transform_single_file.sh
+++ b/servicex_local/templates/transform_single_file.sh
@@ -6,16 +6,18 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # If transformer has already run then we don't need to compile
 if [ ! -d /home/atlas/rel ]; then
   echo "Compile"
-  bash "$SCRIPT_DIR/runner.sh" -c
-  if [ $? != 0 ]; then
-    echo "Compile step failed"
-    exit 1
+  bash --login "$SCRIPT_DIR/runner.sh" -c
+  exit_code=$?
+  if [ $exit_code != 0 ]; then
+    echo "Compile step failed: $exit_code"
+    exit $exit_code
   fi
 fi
 
 echo "Transform a file $1 -> $2"
-bash "$SCRIPT_DIR/runner.sh" -r -d "$1" -o "$2"
-if [ $? != 0 ]; then
-  echo "Transform step failed"
-  exit 1
+bash --login "$SCRIPT_DIR/runner.sh" -r -d "$1" -o "$2"
+exit_code=$?
+if [ $exit_code != 0 ]; then
+  echo "Transform step failed: $exit_code"
+  exit $exit_code
 fi


### PR DESCRIPTION
* When running transform, make sure to run as `login` shell
* Track exit codes as they come back from runnig the compile script.

Fixes #34