### PR TITLE
Fix hangs when text appears on `stdout` after `stderr`

### DIFF
--- a/servicex_local/science_images.py
+++ b/servicex_local/science_images.py
@@ -17,14 +17,12 @@ def run_command_with_logging(command: List[str]) -> None:
     """
     logger = logging.getLogger(__name__)
     process = subprocess.Popen(
-        command, stdout=subprocess.PIPE, stderr=subprocess.PIPE, text=True
+        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
     )
 
     stdout_lines = []
-    stderr_lines = []
 
     assert process.stdout is not None
-    assert process.stderr is not None
 
     for stdout_line in iter(process.stdout.readline, ""):
         stripped_line = stdout_line.strip()
@@ -33,21 +31,14 @@ def run_command_with_logging(command: List[str]) -> None:
             logger.warning(stripped_line)
         else:
             logger.debug(stripped_line)
-    for stderr_line in iter(process.stderr.readline, ""):
-        stripped_line = stderr_line.strip()
-        logger.warning(stripped_line)
-        stderr_lines.append(stripped_line)
 
     process.stdout.close()
-    process.stderr.close()
     return_code = process.wait()
 
     if return_code != 0:
         # Output the log as info
         logger = logging.getLogger(__name__)
         for line in stdout_lines:
-            logger.info(line)
-        for line in stderr_lines:
             logger.info(line)
 
         # TODO: Once we are done with 3.11, get rid of newline. Problem is

--- a/tests/genfiles_raw/query8_stderr/transform_a_file.sh
+++ b/tests/genfiles_raw/query8_stderr/transform_a_file.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+
+# Check if the correct number of arguments is provided
+if [ "$#" -ne 3 ]; then
+    echo "Usage: $0 <input_file> <output_file> <output_format>"
+    exit 1
+fi
+
+# Assign arguments to variables
+input_file=$1
+output_file=$2
+output_format=$3
+
+# Your script logic here\
+echo "Output format: $output_format"
+
+# Touch the output file so it is created.
+touch "$output_file"
+
+# Now lets dump lots of stuff to stderr and stdout
+echo "This is a test message to stderr" 1>&2
+sleep 0.1
+echo "This is a test message to stderr" 1>&2
+sleep 0.1
+echo "This is a test message to stderr" 1>&2
+sleep 0.1
+echo "This is a test message to stderr" 1>&2
+sleep 0.1
+echo "This is a test message to stderr" 1>&2
+sleep 0.1
+echo "This is a test message to stdout"
+sleep 0.1
+echo "This is a test message to stdout"
+sleep 0.1
+echo "This is a test message to stdout"
+sleep 0.1
+echo "This is a test message to stdout"
+sleep 0.1
+echo "This is a test message to stdout"
+sleep 0.1
+echo "This is a test message to stderr" 1>&2
+sleep 0.1
+echo "This is a test message to stderr" 1>&2
+sleep 0.1
+echo "This is a test message to stderr" 1>&2
+sleep 0.1
+echo "This is a test message to stderr" 1>&2
+sleep 0.1
+echo "This is a test message to stderr" 1>&2
+sleep 0.1
+echo "This is a test message to stderr" 1>&2
+sleep 0.1
+echo "This is a test message to stdout"
+
+
+exit 0

--- a/tests/genfiles_raw/query8_stderr/transformer_capabilities.json
+++ b/tests/genfiles_raw/query8_stderr/transformer_capabilities.json
@@ -1,0 +1,11 @@
+{
+  "name": "FuncADL based C++ transformer",
+  "description": "Two different transformers. One for ATLAS reads xAOD files. A second transformer reads CMS Run 1 AOD files",
+  "limitations": "Would be good to note what isn't implemented",
+  "file-formats": [
+    "root"
+  ],
+  "stats-parser": "AODStats",
+  "language": "bash",
+  "command": "/generated/transform_a_file.sh"
+}


### PR DESCRIPTION
* Readout `stderr` and `stdout` by piping them into each other. Avoids the lock condition we were seeing.

Fixes #37