### PR TITLE
Save generated code after request.

### DIFF
--- a/servicex_local/logging_decorator.py
+++ b/servicex_local/logging_decorator.py
@@ -1,0 +1,26 @@
+import logging
+from functools import wraps
+from pathlib import Path
+
+
+def log_to_file(log_file):
+    def decorator(func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
+            logger = logging.getLogger()
+            logger.setLevel(logging.DEBUG)
+            handler = logging.FileHandler(log_file, mode='a')  # Append mode
+            formatter = logging.Formatter(
+                "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
+            )
+            handler.setFormatter(formatter)
+            logger.addHandler(handler)
+            try:
+                return func(*args, **kwargs)
+            finally:
+                logger.removeHandler(handler)
+                handler.close()
+
+        return wrapper
+
+    return decorator

--- a/servicex_local/logging_decorator.py
+++ b/servicex_local/logging_decorator.py
@@ -1,6 +1,5 @@
 import logging
 from functools import wraps
-from pathlib import Path
 
 
 def log_to_file(log_file):
@@ -9,7 +8,7 @@ def log_to_file(log_file):
         def wrapper(*args, **kwargs):
             logger = logging.getLogger()
             logger.setLevel(logging.DEBUG)
-            handler = logging.FileHandler(log_file, mode='a')  # Append mode
+            handler = logging.FileHandler(log_file, mode="a")  # Append mode
             formatter = logging.Formatter(
                 "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
             )

--- a/servicex_local/science_images.py
+++ b/servicex_local/science_images.py
@@ -5,48 +5,60 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import List
 
+from .logging_decorator import log_to_file
 
-def run_command_with_logging(command: List[str]) -> None:
+
+def run_command_with_logging(command: List[str], log_file: Path) -> None:
     """Run a command in a subprocess and log the output.
 
     Args:
         command (List[str]): The command to run
+        log_file (Path): The file to write log messages to
 
     Raises:
         RuntimeError: If the command fails
     """
-    logger = logging.getLogger(__name__)
-    process = subprocess.Popen(
-        command, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True, bufsize=1
-    )
 
-    stdout_lines = []
-
-    assert process.stdout is not None
-
-    for stdout_line in iter(process.stdout.readline, ""):
-        stripped_line = stdout_line.strip()
-        stdout_lines.append(stripped_line)
-        if "error" in stripped_line.lower() or "warning" in stripped_line.lower():
-            logger.warning(stripped_line)
-        else:
-            logger.debug(stripped_line)
-
-    process.stdout.close()
-    return_code = process.wait()
-
-    if return_code != 0:
-        # Output the log as info
+    @log_to_file(log_file)
+    def do_the_work():
         logger = logging.getLogger(__name__)
-        for line in stdout_lines:
-            logger.info(line)
-
-        # TODO: Once we are done with 3.11, get rid of newline. Problem is
-        #       we can't have a \n in an f-string for the older versions of python.
-        raise RuntimeError(
-            f"Failed to run SX science payload locally with exit_code={return_code} "
-            "({' '.join(command)}). See INFO python logging messages for more details"
+        logger.debug("Running command: %s", " ".join(command))
+        process = subprocess.Popen(
+            command,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
         )
+
+        stdout_lines = []
+
+        assert process.stdout is not None
+
+        for stdout_line in iter(process.stdout.readline, ""):
+            stripped_line = stdout_line.strip()
+            stdout_lines.append(stripped_line)
+            if "error" in stripped_line.lower() or "warning" in stripped_line.lower():
+                logger.warning(stripped_line)
+            else:
+                logger.debug(stripped_line)
+
+        process.stdout.close()
+        return_code = process.wait()
+
+        if return_code != 0:
+            # Output the log as info
+            for line in stdout_lines:
+                logger.info(line)
+
+            # TODO: Once we are done with 3.11, get rid of newline. Problem is
+            #       we can't have a \n in an f-string for the older versions of python.
+            raise RuntimeError(
+                f"Failed to run SX science payload locally with exit_code={return_code} "
+                "({' '.join(command)}). See INFO python logging messages for more details"
+            )
+
+    do_the_work()
 
 
 class BaseScienceImage(ABC):
@@ -197,7 +209,9 @@ exit $r
 
             # Call the WSL command via os.system
             command = ["wsl", "-d", self._container, "bash", "-i", wsl_script_path]
-            run_command_with_logging(command)
+            run_command_with_logging(
+                command, log_file=generated_files_dir / "wsl_log.txt"
+            )
             output_paths.append(output_directory / input_path_name)
 
         return output_paths
@@ -315,7 +329,9 @@ sys.exit(exit_code)
                     f"/servicex/output/{output_name}",
                     output_format,
                 ]
-                run_command_with_logging(command)
+                run_command_with_logging(
+                    command, log_file=generated_files_dir / "docker_log.txt"
+                )
                 output_paths.append(output_directory / Path(input_file).name)
 
             except subprocess.CalledProcessError as e:

--- a/servicex_local/science_images.py
+++ b/servicex_local/science_images.py
@@ -38,7 +38,9 @@ def run_command_with_logging(command: List[str], log_file: Path) -> None:
         for stdout_line in iter(process.stdout.readline, ""):
             stripped_line = stdout_line.strip()
             stdout_lines.append(stripped_line)
-            if "error" in stripped_line.lower() or "warning" in stripped_line.lower():
+            if "error" in stripped_line.lower():
+                logger.error(stripped_line)
+            elif "warning" in stripped_line.lower():
                 logger.warning(stripped_line)
             else:
                 logger.debug(stripped_line)

--- a/tests/test_adaptor.py
+++ b/tests/test_adaptor.py
@@ -308,7 +308,7 @@ async def test_adaptor_submit_transform_line_endings(
 
 @pytest.mark.asyncio
 async def test_adaptor_saved_code_on_no_error(
-    code_gen_one_file, science_runner_one_txt_file
+    code_gen_one_file, science_runner_one_txt_file, caplog
 ):
     "By default make sure code is not saved even with error"
 
@@ -331,11 +331,15 @@ async def test_adaptor_saved_code_on_no_error(
         }
     )
 
-    # Call submit_transform and get the request ID
-    request_id = await adaptor.submit_transform(transform_request)
+    # Capture the log output
+    with caplog.at_level(logging.ERROR):
+        await adaptor.submit_transform(transform_request)
 
     # Make sure nothing was written out.
-    assert not Path(f"./{request_id}").exists()
+    log_messages = caplog.text
+    assert not any(
+        "Error during transformation" in msg for msg in log_messages
+    ), "Unexpected error message found in logs"
 
 
 @pytest.mark.asyncio

--- a/tests/test_adaptor.py
+++ b/tests/test_adaptor.py
@@ -23,9 +23,10 @@ from servicex_local import (
 from servicex_local.adaptor import MinioLocalAdaptor
 
 
-@pytest.mark.skip(reason="This test needs wsl2 to be installed")
-def test_adaptor_xaod_wsl2():
+def test_adaptor_xaod_wsl2(request):
     "Run a test with the WSL2 acting as the science image"
+    if not request.config.getoption("--wsl2"):
+        pytest.skip("Use the --wsl2 pytest flag to run this test")
 
     # Dummy out the cache manager so no results are cached.
 
@@ -78,9 +79,11 @@ def test_adaptor_xaod_wsl2():
     assert Path(local_files[0]).exists()
 
 
-@pytest.mark.skip(reason="This test needs docker to be installed")
-def test_adaptor_xaod_docker():
+def test_adaptor_xaod_docker(request):
     "Use docker as back end to make sure our scripts are portable!"
+    if not request.config.getoption("--docker"):
+        pytest.skip("Use the --wsl2 pytest flag to run this test")
+
     # Here starts the test code
     codegen = LocalXAODCodegen()
     science_runner = DockerScienceImage(

--- a/tests/test_science_images.py
+++ b/tests/test_science_images.py
@@ -246,6 +246,10 @@ def test_docker_science_log_warnings(tmp_path, caplog, request):
     assert "this is log line 2" in caplog.text
     assert "this is log line 1" in caplog.text
 
+    # Make sure these lines also appear in the logger output!
+    written_log = (generated_file_directory / "docker_log.txt").read_text()
+    assert "this is log line 2" in written_log
+
 
 @pytest.mark.parametrize(
     "wsl_distro, release, transform_path, exception_message",


### PR DESCRIPTION
* Save code-gen otuput when running to a tmp directory.
* Write out all log messages when running in a file in that same tmp directory
* Write out the commands that were issued for docker or wsl2

## Minor

* Clean up test cases for `test_adaptor` to use the new `pytest` flags.
    * Note that integrated wsl2 and docker things do not yet work - because we don't have a stable servicex integration approach yet.

Adapter should save the generated files if requested... 
Fixes #39