### PR TITLE
Error Capture

### DIFF
--- a/servicex_local/logging_decorator.py
+++ b/servicex_local/logging_decorator.py
@@ -7,7 +7,9 @@ def log_to_file(log_file):
         @wraps(func)
         def wrapper(*args, **kwargs):
             logger = logging.getLogger()
+            original_logging_level = logger.level
             logger.setLevel(logging.DEBUG)
+
             handler = logging.FileHandler(log_file, mode="a")  # Append mode
             formatter = logging.Formatter(
                 "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
@@ -19,6 +21,7 @@ def log_to_file(log_file):
             finally:
                 logger.removeHandler(handler)
                 handler.close()
+                logger.setLevel(original_logging_level)
 
         return wrapper
 

--- a/tests/test_logging_decorator.py
+++ b/tests/test_logging_decorator.py
@@ -24,3 +24,22 @@ def test_logfile_written(tmp_path: Path, caplog: LogCaptureFixture):
 
     lines = [ln for ln in log.read_text().split("\n") if len(ln.strip()) != 0]
     assert len(lines) == 4
+
+
+def test_logfile_no_mess_with_levels(tmp_path: Path, caplog: LogCaptureFixture):
+    log = tmp_path / "func_log.txt"
+
+    @log_to_file(log)
+    def run_me():
+        logging.info("info")
+        logging.debug("debug")
+        logging.warning("warning")
+        logging.error("error")
+
+    root_logger = logging.getLogger()
+    with caplog.at_level(logging.WARNING):
+        assert root_logger.level == logging.WARNING
+        run_me()
+        assert root_logger.level == logging.WARNING
+
+    assert root_logger.level == logging.WARNING

--- a/tests/test_logging_decorator.py
+++ b/tests/test_logging_decorator.py
@@ -1,0 +1,26 @@
+import logging
+from pathlib import Path
+
+from pytest import LogCaptureFixture
+from servicex_local.logging_decorator import log_to_file
+
+
+def test_logfile_written(tmp_path: Path, caplog: LogCaptureFixture):
+    log = tmp_path / "func_log.txt"
+
+    @log_to_file(log)
+    def run_me():
+        logging.info("info")
+        logging.debug("debug")
+        logging.warning("warning")
+        logging.error("error")
+
+    with caplog.at_level(logging.WARNING):
+        run_me()
+
+    assert len(caplog.records) == 2
+    for r in caplog.records:
+        assert r.msg in ["warning", "error"]
+
+    lines = [ln for ln in log.read_text().split("\n") if len(ln.strip()) != 0]
+    assert len(lines) == 4


### PR DESCRIPTION
* Reset the logging level of the master logger once we are done
* Add tests for this
* make sure any error that ends with a ":" in science images has the next line emitted.

Fixes #41