### PR TITLE
Correctly work with https files

### DIFF
--- a/servicex_local/science_images.py
+++ b/servicex_local/science_images.py
@@ -281,7 +281,11 @@ class DockerScienceImage(BaseScienceImage):
             output_name = Path(input_file).name
 
             # Create docker mapping string for the input file if it exists.
-            if input_file.startswith("root://") or input_file.startswith("http://"):
+            if (
+                input_file.startswith("root://")
+                or input_file.startswith("http://")
+                or input_file.startswith("https://")
+            ):
                 input_volume = []
                 container_path = input_file
             else:

--- a/servicex_local/science_images.py
+++ b/servicex_local/science_images.py
@@ -155,7 +155,11 @@ class WSL2ScienceImage(BaseScienceImage):
 
         for input_file in input_files:
             # Check if input_file is a root:// or http:// path
-            if input_file.startswith("root://") or input_file.startswith("http://"):
+            if (
+                input_file.startswith("root://")
+                or input_file.startswith("http://")
+                or input_file.startswith("https://")
+            ):
                 wsl_input_file = input_file
                 input_path_name = Path(input_file.split("/")[-1]).name
             else:

--- a/tests/genfiles_raw/query2_bash/transform_a_file.sh
+++ b/tests/genfiles_raw/query2_bash/transform_a_file.sh
@@ -15,7 +15,7 @@ output_format=$3
 echo "Output format: $output_format"
 
 # Check if the input file exists
-if [[ "$input_file" != root* ]]; then
+if [[ "$input_file" != root* && "$input_file" != http* ]]; then
     if [ ! -f "$input_file" ]; then
         echo "Input file not found!"
         echo "-->   $input_file"

--- a/tests/test_science_images.py
+++ b/tests/test_science_images.py
@@ -28,7 +28,11 @@ def prepare_input_files(
     input_data_directory.mkdir()
     actual_input_files = []
     for file in input_files:
-        if not file.startswith("root://"):
+        if (
+            not file.startswith("root://")
+            and not file.startswith("https://")
+            and not file.startswith("http://")
+        ):
             (input_data_directory / file).touch()
             actual_input_files.append(str(input_data_directory / file))
         else:
@@ -68,6 +72,16 @@ def prepare_input_files(
         (
             "./tests/genfiles_raw/query2_bash",
             ["file1.root", "file2.root"],
+            "sslhep/servicex_func_adl_uproot_transformer:uproot5",
+        ),
+        (
+            "./tests/genfiles_raw/query2_bash",
+            ["http://root.ch/file1"],
+            "sslhep/servicex_func_adl_uproot_transformer:uproot5",
+        ),
+        (
+            "./tests/genfiles_raw/query2_bash",
+            ["https://root.ch/file1"],
             "sslhep/servicex_func_adl_uproot_transformer:uproot5",
         ),
         (

--- a/tests/test_science_images.py
+++ b/tests/test_science_images.py
@@ -166,6 +166,18 @@ def test_docker_science(
             "24.2.41",
             "atlas_al9",
         ),
+        (
+            "./tests/genfiles_raw/query2_bash",
+            ["http://root.ch/file1.root"],
+            "24.2.41",
+            "atlas_al9",
+        ),
+        (
+            "./tests/genfiles_raw/query2_bash",
+            ["https://root.ch/file1.root"],
+            "24.2.41",
+            "atlas_al9",
+        ),
     ],
 )
 def test_wsl2_science(


### PR DESCRIPTION
* https filenames supported by both docker and wsl2 backends.
* Improve testing for both types of files.

Fixes #54