### PR TITLE
Add memory limits for docker

### DIFF
--- a/servicex_local/science_images.py
+++ b/servicex_local/science_images.py
@@ -345,7 +345,14 @@ sys.exit(exit_code)
                 f.write(kick_off)
 
             memory_options = (
-                ["-m", f"{self.memory_limit}g"] if self.memory_limit else []
+                [
+                    "-m",
+                    f"{self.memory_limit}g",
+                    "--memory-swap",
+                    f"{self.memory_limit}g",
+                ]
+                if self.memory_limit
+                else []
             )
 
             try:

--- a/servicex_local/science_images.py
+++ b/servicex_local/science_images.py
@@ -236,13 +236,15 @@ exit $r
 
 
 class DockerScienceImage(BaseScienceImage):
-    def __init__(self, image_name: str):
+    def __init__(self, image_name: str, memory_limit: Optional[float] = None):
         """Science image will run in a Docker container with the specified image name/tag
 
         Args:
             image_name (str): The name/tag of the Docker image to be used
+            memory_limit (Optional[float]): Memory limit for the Docker container in GB
         """
         self.image_name = image_name
+        self.memory_limit = memory_limit
 
     def transform(
         self,
@@ -342,6 +344,10 @@ sys.exit(exit_code)
             with open(generated_files_dir / "kick_off.py", "w") as f:
                 f.write(kick_off)
 
+            memory_options = (
+                ["-m", f"{self.memory_limit}g"] if self.memory_limit else []
+            )
+
             try:
                 command = [
                     "docker",
@@ -349,6 +355,7 @@ sys.exit(exit_code)
                     "--name",
                     container_name,
                     "--rm",
+                    *memory_options,
                     "-v",
                     f"{generated_files_dir.absolute()}:/generated",
                     "-v",

--- a/tests/test_science_images.py
+++ b/tests/test_science_images.py
@@ -356,6 +356,7 @@ def test_docker_command_memory_limit(tmp_path: Path):
     assert captured_command["command"][0] == "docker"
     assert "1.5g" in captured_command["command"]
     assert "-m" in captured_command["command"]
+    assert "--memory-swap" in captured_command["command"]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_science_images.py
+++ b/tests/test_science_images.py
@@ -282,6 +282,82 @@ def test_docker_science_log_warnings(tmp_path, caplog, request):
     assert "this is log line 2" in written_log
 
 
+def test_docker_command(tmp_path: Path):
+
+    generated_file_directory, actual_input_files, output_file_directory = (
+        prepare_input_files(
+            tmp_path, "tests/genfiles_raw/query7_logging_warnings", ["file1.root"]
+        )
+    )
+
+    from unittest.mock import patch
+
+    captured_command = {}
+
+    def mock_run_command_with_logging(command, log_file):
+        captured_command["command"] = command
+        captured_command["log_file"] = log_file
+
+        # Create the required output file
+        (output_file_directory / "junk.txt").touch()
+
+    with patch(
+        "servicex_local.science_images.run_command_with_logging",
+        side_effect=mock_run_command_with_logging,
+    ):
+        docker = DockerScienceImage(
+            "sslhep/servicex_func_adl_uproot_transformer:uproot5"
+        )
+        docker.transform(
+            generated_file_directory,
+            actual_input_files,
+            output_file_directory,
+            "root-file",
+        )
+
+    assert captured_command["command"][0] == "docker"
+    assert not ("-m" in captured_command["command"])
+
+
+def test_docker_command_memory_limit(tmp_path: Path):
+
+    generated_file_directory, actual_input_files, output_file_directory = (
+        prepare_input_files(
+            tmp_path, "tests/genfiles_raw/query7_logging_warnings", ["file1.root"]
+        )
+    )
+
+    from unittest.mock import patch
+
+    captured_command = {}
+
+    def mock_run_command_with_logging(command, log_file):
+        captured_command["command"] = command
+        captured_command["log_file"] = log_file
+
+        # Create the required output file
+        (output_file_directory / "junk.txt").touch()
+
+    with patch(
+        "servicex_local.science_images.run_command_with_logging",
+        side_effect=mock_run_command_with_logging,
+    ):
+        docker = DockerScienceImage(
+            "sslhep/servicex_func_adl_uproot_transformer:uproot5", memory_limit=1.5
+        )
+        docker.transform(
+            generated_file_directory,
+            actual_input_files,
+            output_file_directory,
+            "root-file",
+        )
+
+    # Now you can assert on captured_command['command'] as needed
+    assert captured_command["command"][0] == "docker"
+    assert "1.5g" in captured_command["command"]
+    assert "-m" in captured_command["command"]
+
+
 @pytest.mark.parametrize(
     "wsl_distro, release, transform_path, exception_message",
     [


### PR DESCRIPTION
* Add the `memory_limit` argument to the docker science image
* Allows testing in memory constrained situations.

Fixes #59
