### PR TITLE
Uuser-Specific cache dir

### DIFF
--- a/servicex_local/adaptor.py
+++ b/servicex_local/adaptor.py
@@ -14,6 +14,7 @@ from servicex.models import (
     TransformRequest,
     TransformStatus,
 )
+
 from servicex_local.codegen import SXCodeGen
 from servicex_local.science_images import BaseScienceImage
 

--- a/servicex_local/deliver.py
+++ b/servicex_local/deliver.py
@@ -1,3 +1,4 @@
+import getpass
 import hashlib
 import json
 import tempfile
@@ -22,9 +23,11 @@ def _sample_run_info(
 
     Args:
         g (General): A general configuration object.
-        samples (List[Sample]): A list of Sample objects containing information about each sample.
+        samples (List[Sample]): A list of Sample objects containing information
+            about each sample.
     Yields:
-        TransformRequest: A TransformRequest object for each sample in the list.
+        TransformRequest:
+            A TransformRequest object for each sample in the list.
     """
     for s in samples:
         selection = (
@@ -55,7 +58,8 @@ def _sample_run_info(
 
 def _generate_cache_key(tq: TransformRequest) -> str:
     """
-    Generate a cache key based on the file_list and selection of the TransformRequest.
+    Generate a cache key based on the file_list and selection of the
+    TransformRequest.
 
     Args:
         tq (TransformRequest): The TransformRequest object.
@@ -66,8 +70,8 @@ def _generate_cache_key(tq: TransformRequest) -> str:
     return hashlib.md5(key.encode()).hexdigest()
 
 
-CACHE_DIR = Path(tempfile.gettempdir()) / "servicex"
-CACHE_FILE = CACHE_DIR / "cache.json"
+CACHE_DIR: Path = Path(tempfile.gettempdir()) / f"servicex_{getpass.getuser()}"
+CACHE_FILE: Path = CACHE_DIR / "cache.json"
 
 
 def _load_cache() -> dict[str, Any]:

--- a/servicex_local/deliver.py
+++ b/servicex_local/deliver.py
@@ -2,15 +2,16 @@ import getpass
 import hashlib
 import json
 import tempfile
-from typing import Any, Generator, List
-from pathlib import Path
 from datetime import datetime
+from pathlib import Path
+from typing import Any, Generator, List
 
 from make_it_sync import make_sync
 from servicex import General, ResultDestination, Sample, ServiceXSpec
 from servicex.models import ResultFormat, TransformRequest, TransformStatus
 from servicex.query_core import QueryStringGenerator
 from servicex.servicex_client import GuardList
+
 from servicex_local import SXLocalAdaptor
 from servicex_local.adaptor import MinioLocalAdaptor
 

--- a/tests/test_adaptor.py
+++ b/tests/test_adaptor.py
@@ -1,3 +1,4 @@
+import getpass
 import logging
 import tempfile
 import uuid
@@ -76,7 +77,10 @@ async def test_adaptor_submit_transform_one_file(
     mock_codegen.gen_code.assert_called_once()
 
     # Verify the output directory contains one file
-    output_directory = Path(tempfile.gettempdir()) / f"servicex/{request_id}"
+    output_directory: Path = Path(tempfile.gettempdir()).joinpath(
+        f"servicex_{getpass.getuser()}",
+        request_id,
+    )
     output_files = list(output_directory.glob("*"))
     assert len(output_files) == 1
     assert output_files[0].name == "output_file.txt"
@@ -116,7 +120,10 @@ def code_gen_one_file() -> MagicMock:
 
 @pytest.fixture()
 def code_gen_error() -> MagicMock:
-    "Fail while writing a code-gen, and make sure that the file is actually written out."
+    """
+    Fail while writing a code-gen, and make sure the file is actually
+    written out.
+    """
 
     def generate_files(query: str, directory: Path):
         f = directory / "run_me.sh"
@@ -141,8 +148,8 @@ def science_runner_one_txt_file() -> MagicMock:
         output_file = output_directory / "output_file.txt"
         output_file.write_text("Hello, world!")
 
-        # Check all .sh files in the generated_files_dir directory for anything with linux line
-        # endings. If we find one, we should assert.
+        # Check all .sh files in the generated_files_dir directory for anything
+        # with Linux line endings. If we find one, we should assert.
         for file in generated_files_dir.glob("*.sh"):
             with file.open("rb") as f:
                 text = f.read().decode("utf-8")
@@ -266,7 +273,8 @@ async def test_adaptor_saved_code_on_error(
         ),
         None,
     )
-    assert error_message is not None, "Expected error message not found in logs"
+    msg = "Expected error message not found in logs"
+    assert error_message is not None, msg
     directory_path = error_message.split("found at: ")[1].strip()
     d = Path(directory_path)
     assert d.exists()
@@ -306,7 +314,10 @@ async def test_minio_list_bucket():
 
     # Mock the output directory to point to the temporary directory
     adaptor.request_id = "test_request_id"
-    output_directory = Path(tempfile.gettempdir()) / f"servicex/{adaptor.request_id}"
+    output_directory: Path = (
+        Path(tempfile.gettempdir())
+        / f"servicex_{getpass.getuser()}/{adaptor.request_id}"
+    )
     output_directory.mkdir(parents=True, exist_ok=True)
     (output_directory / "file1.txt").write_text("content1")
     (output_directory / "file2.txt").write_text("content2")
@@ -327,7 +338,10 @@ async def test_minio_download_file():
 
     # Mock the output directory to point to the temporary directory
     adaptor.request_id = "test_request_id"
-    output_directory = Path(tempfile.gettempdir()) / f"servicex/{adaptor.request_id}"
+    output_directory: Path = (
+        Path(tempfile.gettempdir())
+        / f"servicex_{getpass.getuser()}/{adaptor.request_id}"
+    )
     output_directory.mkdir(parents=True, exist_ok=True)
     (output_directory / "file1.txt").write_text("content1")
 
@@ -346,7 +360,10 @@ async def test_minio_get_signed_url():
 
     # Mock the output directory to point to the temporary directory
     adaptor.request_id = "test_request_id"
-    output_directory = Path(tempfile.gettempdir()) / f"servicex/{adaptor.request_id}"
+    output_directory: Path = (
+        Path(tempfile.gettempdir())
+        / f"servicex_{getpass.getuser()}/{adaptor.request_id}"
+    )
     output_directory.mkdir(parents=True, exist_ok=True)
     (output_directory / "file1.txt").write_text("content1")
 

--- a/tests/test_adaptor.py
+++ b/tests/test_adaptor.py
@@ -7,16 +7,9 @@ from unittest.mock import MagicMock
 
 import pytest
 from servicex import ResultDestination
-from servicex.models import (
-    ResultFormat,
-    Status,
-    TransformRequest,
-    TransformStatus,
-)
+from servicex.models import ResultFormat, Status, TransformRequest, TransformStatus
 
-from servicex_local import (
-    SXLocalAdaptor,
-)
+from servicex_local import SXLocalAdaptor
 from servicex_local.adaptor import MinioLocalAdaptor
 
 

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -1,4 +1,5 @@
 import os
+import getpass
 import tempfile
 import uuid
 from datetime import datetime
@@ -6,7 +7,12 @@ from pathlib import Path
 
 import pytest
 from servicex import General, ResultDestination, Sample, ServiceXSpec, dataset
-from servicex.models import ResultFormat, Status, TransformRequest, TransformStatus
+from servicex.models import (
+    ResultFormat,
+    Status,
+    TransformRequest,
+    TransformStatus,
+)
 from servicex.query_core import QueryStringGenerator
 
 from servicex_local import deliver
@@ -17,7 +23,9 @@ def restore_cache():
     """
     Fixture to restore the cache database to its original form after each test.
     """
-    cache_dir = Path(tempfile.gettempdir()) / "servicex"
+    cache_dir: Path = (
+        Path(tempfile.gettempdir()) / f"servicex_{getpass.getuser()}"
+    )  # noqa: E501
     cache_file = cache_dir / "cache.json"
     original_cache = None
 
@@ -53,7 +61,7 @@ def simple_adaptor():
 
             file_path = (
                 Path(tempfile.gettempdir())
-                / "servicex"
+                / f"servicex_{getpass.getuser()}"
                 / self._request_id
                 / "file1.root"
             )
@@ -96,7 +104,9 @@ def test_deliver_spec_simple(simple_adaptor):
         General=General(),
         Sample=[
             Sample(
-                Name="test_me", Dataset=dataset.FileList("test.root"), Query="query1"
+                Name="test_me",
+                Dataset=dataset.FileList("test.root"),
+                Query="query1",
             )
         ],
     )
@@ -150,7 +160,9 @@ def test_deliver_spec_simple_cache_hit(simple_adaptor):
         General=General(),
         Sample=[
             Sample(
-                Name="test_me", Dataset=dataset.FileList("test.root"), Query="query1"
+                Name="test_me",
+                Dataset=dataset.FileList("test.root"),
+                Query="query1",
             )
         ],
     )
@@ -168,7 +180,9 @@ def test_deliver_spec_simple_cache_ignore(simple_adaptor):
         General=General(),
         Sample=[
             Sample(
-                Name="test_me", Dataset=dataset.FileList("test.root"), Query="query1"
+                Name="test_me",
+                Dataset=dataset.FileList("test.root"),
+                Query="query1",
             )
         ],
     )

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -1,5 +1,5 @@
-import os
 import getpass
+import os
 import tempfile
 import uuid
 from datetime import datetime
@@ -7,12 +7,7 @@ from pathlib import Path
 
 import pytest
 from servicex import General, ResultDestination, Sample, ServiceXSpec, dataset
-from servicex.models import (
-    ResultFormat,
-    Status,
-    TransformRequest,
-    TransformStatus,
-)
+from servicex.models import ResultFormat, Status, TransformRequest, TransformStatus
 from servicex.query_core import QueryStringGenerator
 
 from servicex_local import deliver


### PR DESCRIPTION
## Summary
- isolate cache under user-specific temp directory
- adjust tests for user-scoped cache paths

Fixes #68

## Testing
- `black servicex_local/adaptor.py tests/test_adaptor.py tests/test_deliver.py servicex_local/deliver.py`
- `flake8 servicex_local/adaptor.py servicex_local/deliver.py tests/test_adaptor.py tests/test_deliver.py`
- `pytest`
- Also ran `organize imports` on all changed files.

------
https://chatgpt.com/codex/tasks/task_e_68ba93a846148320850d9e6dbaa8b5cc