### PR TITLE
Resolve generated kick_off.py paths relative to script directory

### DIFF
--- a/servicex_local/science_images.py
+++ b/servicex_local/science_images.py
@@ -118,9 +118,16 @@ x509up_path = "/tmp/grid-security/x509up"
 if os.path.exists(x509up_path):
     os.chmod(x509up_path, 0o600)
 
-with open("/generated/transformer_capabilities.json") as f:
+script_dir = os.path.dirname(os.path.abspath(__file__))
+with open(os.path.join(script_dir, "transformer_capabilities.json")) as f:
     info = json.load(f)
+
 file_to_run = info["command"]
+if file_to_run.startswith("/generated/"):
+    file_to_run = os.path.join(script_dir, file_to_run.removeprefix("/generated/"))
+elif not os.path.isabs(file_to_run):
+    file_to_run = os.path.join(script_dir, file_to_run)
+
 arg1 = sys.argv[1]
 arg2 = sys.argv[2]
 arg3 = sys.argv[3]
@@ -214,7 +221,6 @@ class WSL2ScienceImage(BaseScienceImage):
         assert (
             generated_files_dir.exists()
         ), f"Missing generate files directory: {generated_files_dir}!"
-        wsl_generated_files_dir = self._convert_to_wsl_path(generated_files_dir)
 
         for input_file in input_files:
             # Check if input_file is a root:// or http:// path
@@ -243,16 +249,21 @@ if os.path.exists(x509up_path):
     os.chmod(x509up_path, 0o600)
     os.system("ls -l " + x509up_path)
 
-with open("{wsl_generated_files_dir}/transformer_capabilities.json") as f:
+script_dir = os.path.dirname(os.path.abspath(__file__))
+with open(os.path.join(script_dir, "transformer_capabilities.json")) as f:
     info = json.load(f)
+
 file_to_run = info["command"]
-# Strip off the default /generated from the file name.
-file_to_run = file_to_run.replace("/generated", "")
+if file_to_run.startswith("/generated/"):
+    file_to_run = os.path.join(script_dir, file_to_run.removeprefix("/generated/"))
+elif not os.path.isabs(file_to_run):
+    file_to_run = os.path.join(script_dir, file_to_run)
+
 if info["language"] == "python":
-    ret_code = os.system("python3 {wsl_generated_files_dir}/" + file_to_run + " {wsl_input_file} "
+    ret_code = os.system("python3 " + file_to_run + " {wsl_input_file} "
         + "{wsl_output_directory}/{input_path_name} {output_format}")
 elif info["language"] == "bash":
-    ret_code = os.system("bash {wsl_generated_files_dir}/" + file_to_run
+    ret_code = os.system("bash " + file_to_run
         + " {wsl_input_file} {wsl_output_directory}/{input_path_name} {output_format}")
 else:
     raise ValueError("Unsupported language: " + info["language"])
@@ -269,10 +280,12 @@ tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
 cd $tmp_dir
 pwd
 
+script_dir="$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)"
+
 # source /etc/profile.d/startup-atlas.sh
 setupATLAS
 asetup AnalysisBase,{self._release},here
-python {wsl_generated_files_dir}/kick_off.py
+python "$script_dir/kick_off.py"
 r=$?
 exit $r
 """

--- a/servicex_local/science_images.py
+++ b/servicex_local/science_images.py
@@ -135,9 +135,16 @@ x509up_path = "/tmp/grid-security/x509up"
 if os.path.exists(x509up_path):
     os.chmod(x509up_path, 0o600)
 
-with open("/generated/transformer_capabilities.json") as f:
+script_dir = os.path.dirname(os.path.abspath(__file__))
+with open(os.path.join(script_dir, "transformer_capabilities.json")) as f:
     info = json.load(f)
+
 file_to_run = info["command"]
+if file_to_run.startswith("/generated/"):
+    file_to_run = os.path.join(script_dir, file_to_run.removeprefix("/generated/"))
+elif not os.path.isabs(file_to_run):
+    file_to_run = os.path.join(script_dir, file_to_run)
+
 arg1 = sys.argv[1]
 arg2 = sys.argv[2]
 arg3 = sys.argv[3]
@@ -231,7 +238,6 @@ class WSL2ScienceImage(BaseScienceImage):
         assert (
             generated_files_dir.exists()
         ), f"Missing generate files directory: {generated_files_dir}!"
-        wsl_generated_files_dir = self._convert_to_wsl_path(generated_files_dir)
 
         for input_file in input_files:
             # Check if input_file is a root:// or http:// path
@@ -260,16 +266,21 @@ if os.path.exists(x509up_path):
     os.chmod(x509up_path, 0o600)
     os.system("ls -l " + x509up_path)
 
-with open("{wsl_generated_files_dir}/transformer_capabilities.json") as f:
+script_dir = os.path.dirname(os.path.abspath(__file__))
+with open(os.path.join(script_dir, "transformer_capabilities.json")) as f:
     info = json.load(f)
+
 file_to_run = info["command"]
-# Strip off the default /generated from the file name.
-file_to_run = file_to_run.replace("/generated", "")
+if file_to_run.startswith("/generated/"):
+    file_to_run = os.path.join(script_dir, file_to_run.removeprefix("/generated/"))
+elif not os.path.isabs(file_to_run):
+    file_to_run = os.path.join(script_dir, file_to_run)
+
 if info["language"] == "python":
-    ret_code = os.system("python3 {wsl_generated_files_dir}/" + file_to_run + " {wsl_input_file} "
+    ret_code = os.system("python3 " + file_to_run + " {wsl_input_file} "
         + "{wsl_output_directory}/{input_path_name} {output_format}")
 elif info["language"] == "bash":
-    ret_code = os.system("bash {wsl_generated_files_dir}/" + file_to_run
+    ret_code = os.system("bash " + file_to_run
         + " {wsl_input_file} {wsl_output_directory}/{input_path_name} {output_format}")
 else:
     raise ValueError("Unsupported language: " + info["language"])
@@ -286,10 +297,12 @@ tmp_dir=$(mktemp -d -t ci-XXXXXXXXXX)
 cd $tmp_dir
 pwd
 
+script_dir="$(cd "$(dirname "${{BASH_SOURCE[0]}}")" && pwd)"
+
 # source /etc/profile.d/startup-atlas.sh
 setupATLAS
 asetup AnalysisBase,{self._release},here
-python {wsl_generated_files_dir}/kick_off.py
+python "$script_dir/kick_off.py"
 r=$?
 exit $r
 """


### PR DESCRIPTION
### Motivation
- Ensure generated `kick_off.py` scripts resolve the capabilities file and transformer command relative to the script file itself so the generated runner works when executed from another working directory or after being copied.
- Fix remaining hardcoded `/generated/...` references that were missed by the previous WSL script fix.

### Description
- Updated the default `kick_off.py` template in `servicex_local/science_images.py` to compute `script_dir` from `__file__`, load `transformer_capabilities.json` from `script_dir`, and normalize `info["command"]` so `/generated/...` and relative paths become script-relative while leaving other absolute paths unchanged.
- Applied the same `script_dir` + command-normalization logic to the WSL `kick_off.py` template embedded in `WSL2ScienceImage.transform` so the WSL-generated runner also resolves paths correctly.
- Changed the generated WSL wrapper to invoke `python "$script_dir/kick_off.py"` instead of referring to the old generated-directory path.
- Removed the now-unused `wsl_generated_files_dir` local variable in `WSL2ScienceImage.transform` after switching to script-relative resolution.

### Testing
- Ran `python -m black --check servicex_local/science_images.py`, which passed.
- Ran `python -m flake8 servicex_local/science_images.py`, which failed due to existing `E501` line-length violations in the file and not caused by these changes.
- Ran `pytest`, which failed with pre-existing `TransformStatus` validation errors in adaptor/deliver tests and are unrelated to the `kick_off.py` path fixes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6984542ed294832096a2c1a7a7cba78b)