### PR TITLE
Use ServiceX.yaml to select Cache Dir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -132,3 +132,5 @@ servicex.yaml
 
 wsl_transform_script.sh
 kick_off.py
+
+.DS_Store

--- a/servicex_local/adaptor.py
+++ b/servicex_local/adaptor.py
@@ -50,7 +50,7 @@ class SXLocalAdaptor:
 
     async def _get_authorization(self):
         "Dummied out - we always have authorization"
-        
+
         pass
 
     async def get_transforms(self) -> List[TransformStatus]:

--- a/servicex_local/adaptor.py
+++ b/servicex_local/adaptor.py
@@ -243,14 +243,14 @@ class MinioLocalAdaptor:
         return result_files
 
     async def download_file(
-        self, object_name: str, local_dir: str, shorten_filename: bool = False
+        self, object_name: str, local_dir: Path, shorten_filename: bool = False
     ) -> Path:
         output_directory: Path = (
             Path(tempfile.gettempdir())
             / f"servicex_{getpass.getuser()}/{self.request_id}"
         )
         source_path = output_directory / object_name
-        destination_path = Path(local_dir) / object_name
+        destination_path = local_dir / object_name
 
         if not source_path.exists():
             raise FileNotFoundError(

--- a/servicex_local/adaptor.py
+++ b/servicex_local/adaptor.py
@@ -39,12 +39,11 @@ class SXLocalAdaptor:
         self,
         codegen: SXCodeGen,
         science_runner: BaseScienceImage,
-        codegen_name: str,
+        cache_dir: Path,
         url: str,
     ):
         self.codegen = codegen
         self.science_runner = science_runner
-        self.codegen_name = codegen_name
         self.url = url
         self.transform_status_store: Dict[str, TransformStatus] = {}
 
@@ -59,10 +58,6 @@ class SXLocalAdaptor:
         raise NotImplementedError(
             "get_transforms is not implemented for SXLocalAdaptor"
         )
-
-    def get_code_generators(self) -> Dict[str, List[str]]:
-        # Return the code generator name provided during initialization
-        return {self.codegen_name: []}
 
     async def get_datasets(
         self,

--- a/servicex_local/adaptor.py
+++ b/servicex_local/adaptor.py
@@ -44,12 +44,13 @@ class SXLocalAdaptor:
     ):
         self.codegen = codegen
         self.science_runner = science_runner
+        self.cache_dir = cache_dir / f"servicex_{getpass.getuser()}"
         self.url = url
         self.transform_status_store: Dict[str, TransformStatus] = {}
 
     async def _get_authorization(self):
         "Dummied out - we always have authorization"
-        # TODO: Why is this method start with a `_`?
+        
         pass
 
     async def get_transforms(self) -> List[TransformStatus]:

--- a/servicex_local/deliver.py
+++ b/servicex_local/deliver.py
@@ -154,8 +154,9 @@ async def deliver_async(
 
         # Build the list of results.
         minio_results = MinioLocalAdaptor.for_transform(status)
+        download_dir = adaptor.cache_dir / status.request_id
         files = [
-            await minio_results.get_signed_url(n.filename)
+            await minio_results.download_file(n.filename, download_dir)
             for n in await minio_results.list_bucket()
         ]
         outputs = GuardList(files)

--- a/servicex_local/deliver.py
+++ b/servicex_local/deliver.py
@@ -71,32 +71,41 @@ def _generate_cache_key(tq: TransformRequest) -> str:
     return hashlib.md5(key.encode()).hexdigest()
 
 
-CACHE_DIR: Path = Path(tempfile.gettempdir()) / f"servicex_{getpass.getuser()}"
-CACHE_FILE: Path = CACHE_DIR / "cache.json"
+def _get_cache_file(cache_dir: Path) -> Path:
+    """
+    Get the path to the cache file.
+
+    Args:
+        cache_dir (Path): The directory where the cache file is stored.
+    Returns:
+        Path: The path to the cache file.
+    """
+    return cache_dir / "cache.json"
 
 
-def _load_cache() -> dict[str, Any]:
+def _load_cache(cache_dir: Path) -> dict[str, Any]:
     """
     Load the cache from the file system.
 
     Returns:
         dict[str, Any]: The cache dictionary.
     """
-    if not CACHE_FILE.exists():
+    if not _get_cache_file(cache_dir).exists():
         return {}
-    with CACHE_FILE.open("r") as f:
+    with _get_cache_file(cache_dir).open("r") as f:
         return json.load(f)
 
 
-def _save_cache(cache: dict[str, Any]) -> None:
+def _save_cache(cache: dict[str, Any], cache_dir: Path) -> None:
     """
     Save the cache to the file system.
 
     Args:
         cache (dict[str, Any]): The cache dictionary.
+        cache_dir (Path): The directory where the cache file is stored.
     """
-    CACHE_DIR.mkdir(parents=True, exist_ok=True)
-    with CACHE_FILE.open("w") as f:
+    cache_dir.mkdir(parents=True, exist_ok=True)
+    with _get_cache_file(cache_dir).open("w") as f:
         json.dump(cache, f)
 
 
@@ -108,7 +117,7 @@ async def deliver_async(
 ) -> dict[str, GuardList] | None:
 
     results: dict[str, GuardList] = {}
-    cache = _load_cache()  # Load cache from file system
+    cache = _load_cache(adaptor.cache_dir)  # Load cache from file system
 
     # Run the samples one by one.
     for tq in _sample_run_info(spec.General, spec.Sample):
@@ -141,7 +150,7 @@ async def deliver_async(
             )
 
             cache[cache_key] = info
-            _save_cache(cache)  # Save cache to file system
+            _save_cache(cache, adaptor.cache_dir)
 
         # Build the list of results.
         minio_results = MinioLocalAdaptor.for_transform(status)

--- a/servicex_local/deliver.py
+++ b/servicex_local/deliver.py
@@ -1,7 +1,5 @@
-import getpass
 import hashlib
 import json
-import tempfile
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Generator, List

--- a/servicex_local/utils.py
+++ b/servicex_local/utils.py
@@ -122,18 +122,17 @@ def install_sx_local(
     from servicex_local import LocalXAODCodegen, SXLocalAdaptor
     from servicex.configuration import Configuration
 
-    # TODO: Add a test to make sure this returns the right directory.
-    # TODO: Add test for what happens with no servicex.yaml
     try:
         sx_cfg = Configuration.read()
         cache_dir = Path(sx_cfg.cache_path).resolve()
     except NameError:
         import tempfile
-        
-        with tempfile.TemporaryDirectory() as temp_dir:
-            cache_dir = Path(temp_dir).resolve()
-            logging.warning(f"Could not read a ServiceX.yaml. Using temporary directory for cache.")
-            
+
+        cache_dir = Path(tempfile.mkdtemp()).resolve()
+        logging.warning(
+            "Could not read a ServiceX.yaml. Using temporary directory %s for cache.",
+            cache_dir,
+        )
 
     codegen = LocalXAODCodegen()
 

--- a/servicex_local/utils.py
+++ b/servicex_local/utils.py
@@ -117,9 +117,27 @@ def install_sx_local(
     Returns:
         Tuple[str, SXLocalAdaptor]: Codegen name, adaptor.
     """
-    from servicex_local import LocalXAODCodegen, SXLocalAdaptor
+    from pathlib import Path
 
-    codegen_name = "local"
+    from servicex_local import LocalXAODCodegen, SXLocalAdaptor
+    from servicex.configuration import Configuration
+
+    # TODO: Add a test to make sure this returns the right directory.
+    # TODO: Add test for what happens with no servicex.yaml
+    try:
+        sx_cfg = Configuration.read()
+        cache_dir = Path(sx_cfg.cache_path).resolve()
+        
+        logging.debug(f"Read ServiceX configuration: {sx_cfg}")
+        logging.debug(f"Using cache location: {cache_dir}")
+    except NameError:
+        import tempfile
+        
+        with tempfile.TemporaryDirectory() as temp_dir:
+            cache_dir = Path(temp_dir).resolve()
+            logging.warning(f"Could not read a ServiceX.yaml. Using temporary directory for cache: {cache_dir}")
+            
+
     codegen = LocalXAODCodegen()
 
     if platform == Platform.docker:
@@ -142,8 +160,8 @@ def install_sx_local(
         raise ValueError(f"Unknown platform {platform}")
 
     adaptor = SXLocalAdaptor(
-        codegen, science_runner, codegen_name, f"http://localhost:{host_port}"
+        codegen, science_runner, f"http://localhost:{host_port}", cache_dir
     )
 
-    logging.info("Using local ServiceX endpoint: codegen %s", codegen_name)
-    return codegen_name, adaptor
+    logging.info(f"Using local ServiceX endpoint: {codegen}")
+    return adaptor

--- a/servicex_local/utils.py
+++ b/servicex_local/utils.py
@@ -127,15 +127,12 @@ def install_sx_local(
     try:
         sx_cfg = Configuration.read()
         cache_dir = Path(sx_cfg.cache_path).resolve()
-        
-        logging.debug(f"Read ServiceX configuration: {sx_cfg}")
-        logging.debug(f"Using cache location: {cache_dir}")
     except NameError:
         import tempfile
         
         with tempfile.TemporaryDirectory() as temp_dir:
             cache_dir = Path(temp_dir).resolve()
-            logging.warning(f"Could not read a ServiceX.yaml. Using temporary directory for cache: {cache_dir}")
+            logging.warning(f"Could not read a ServiceX.yaml. Using temporary directory for cache.")
             
 
     codegen = LocalXAODCodegen()
@@ -160,8 +157,9 @@ def install_sx_local(
         raise ValueError(f"Unknown platform {platform}")
 
     adaptor = SXLocalAdaptor(
-        codegen, science_runner, f"http://localhost:{host_port}", cache_dir
+        codegen, science_runner, cache_dir, f"http://localhost:{host_port}"
     )
 
     logging.info(f"Using local ServiceX endpoint: {codegen}")
+    logging.info(f"Cache being save to; {adaptor.cache_dir}")
     return adaptor

--- a/tests/test_adaptor.py
+++ b/tests/test_adaptor.py
@@ -17,7 +17,7 @@ def test_adaptor_url():
     codegen = MagicMock()
     science_runner = MagicMock()
     url = "http://localhost:5000"
-    adaptor = SXLocalAdaptor(codegen, science_runner, "mock_codegen", url)
+    adaptor = SXLocalAdaptor(codegen, science_runner, Path(tempfile.gettempdir()), url)
 
     assert adaptor.url == url
 
@@ -36,7 +36,7 @@ async def test_adaptor_submit_transform_one_file(
     adaptor = SXLocalAdaptor(
         mock_codegen,
         science_runner_one_txt_file,
-        "mock_codegen",
+        Path(tempfile.gettempdir()),
         "http://localhost:5000",
     )
 
@@ -167,7 +167,7 @@ async def test_adaptor_submit_transform_line_endings(
     adaptor = SXLocalAdaptor(
         code_gen_one_windows_file,
         science_runner_one_txt_file,
-        "mock_codegen",
+        Path(tempfile.gettempdir()),
         "http://localhost:5000",
     )
 
@@ -200,7 +200,7 @@ async def test_adaptor_saved_code_on_no_error(
     adaptor = SXLocalAdaptor(
         code_gen_one_file,
         science_runner_one_txt_file,
-        "mock_codegen",
+        Path(tempfile.gettempdir()),
         "http://localhost:5000",
     )
 
@@ -236,7 +236,7 @@ async def test_adaptor_saved_code_on_error(
     adaptor = SXLocalAdaptor(
         code_gen_error,
         science_runner_one_txt_file,
-        "mock_codegen",
+        Path(tempfile.gettempdir()),
         "http://localhost:5000",
     )
 
@@ -341,7 +341,7 @@ async def test_minio_download_file():
 
     # Call download_file and verify the result
     local_dir = Path(tempfile.gettempdir()) / "local_dir"
-    downloaded_file = await adaptor.download_file("file1.txt", str(local_dir))
+    downloaded_file = await adaptor.download_file("file1.txt", local_dir)
     assert downloaded_file.exists()
     assert downloaded_file.read_text() == "content1"
 

--- a/tests/test_adaptor.py
+++ b/tests/test_adaptor.py
@@ -22,6 +22,16 @@ def test_adaptor_url():
     assert adaptor.url == url
 
 
+def test_adaptor_cache_dir_namespaced_by_user(tmp_path):
+    "The adaptor namespaces the supplied cache_dir with servicex_<user>."
+    codegen = MagicMock()
+    science_runner = MagicMock()
+
+    adaptor = SXLocalAdaptor(codegen, science_runner, tmp_path, "http://localhost:5000")
+
+    assert adaptor.cache_dir == tmp_path / f"servicex_{getpass.getuser()}"
+
+
 @pytest.mark.asyncio
 async def test_adaptor_submit_transform_one_file(
     science_runner_one_txt_file: MagicMock,

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -44,6 +44,9 @@ def simple_adaptor():
         def __init__(self):
             self._request_id = None
             self._submit_called = 0
+            self.cache_dir = (
+                Path(tempfile.gettempdir()) / f"servicex_{getpass.getuser()}"
+            )
 
         @property
         def submit_called(self):
@@ -113,9 +116,7 @@ def test_deliver_spec_simple(simple_adaptor):
     assert "test_me" in r
     files = r["test_me"]
     assert len(files) == 1
-    local_path = Path(files[0].replace("file:///", "/"))
-    if os.name == "nt":
-        local_path = Path(files[0].replace("file:///", ""))
+    local_path = Path(files[0])
     assert os.path.exists(local_path)
 
 
@@ -143,9 +144,7 @@ def test_deliver_spec_q_string_generator(simple_adaptor):
     assert "test_me" in r
     files = r["test_me"]
     assert len(files) == 1
-    local_path = Path(files[0].replace("file:///", "/"))
-    if os.name == "nt":
-        local_path = Path(files[0].replace("file:///", ""))
+    local_path = Path(files[0])
     assert os.path.exists(local_path)
 
 

--- a/tests/test_deliver.py
+++ b/tests/test_deliver.py
@@ -38,15 +38,19 @@ def restore_cache():
         cache_file.unlink()
 
 
-@pytest.fixture
-def simple_adaptor():
+def _make_adaptor(cache_dir: Path):
+    """Build a minimal in-memory adaptor whose cache_dir is configurable.
+
+    submit_transform writes a fake output file to the location MinioLocalAdaptor
+    reads from (``tempfile.gettempdir() / servicex_<user> / <request_id>``),
+    so MinioLocalAdaptor.list_bucket / download_file work end-to-end.
+    """
+
     class my_adaptor:
         def __init__(self):
             self._request_id = None
             self._submit_called = 0
-            self.cache_dir = (
-                Path(tempfile.gettempdir()) / f"servicex_{getpass.getuser()}"
-            )
+            self.cache_dir = cache_dir
 
         @property
         def submit_called(self):
@@ -94,6 +98,12 @@ def simple_adaptor():
             )
 
     return my_adaptor()
+
+
+@pytest.fixture
+def simple_adaptor():
+    cache_dir = Path(tempfile.gettempdir()) / f"servicex_{getpass.getuser()}"
+    return _make_adaptor(cache_dir)
 
 
 def test_deliver_spec_simple(simple_adaptor):
@@ -189,3 +199,52 @@ def test_deliver_spec_simple_cache_ignore(simple_adaptor):
 
 
 # test for warning for extra arguments that aren't known.
+
+
+def test_deliver_writes_cache_to_adaptor_cache_dir(tmp_path):
+    "deliver() writes cache.json into adaptor.cache_dir, not a hardcoded path."
+    adaptor = _make_adaptor(tmp_path)
+
+    spec = ServiceXSpec(
+        General=General(),
+        Sample=[
+            Sample(
+                Name="test_me",
+                Dataset=dataset.FileList("test.root"),
+                Query="query1",
+            )
+        ],
+    )
+
+    deliver(spec, adaptor=adaptor)
+
+    assert (tmp_path / "cache.json").exists()
+
+
+def test_deliver_downloads_files_to_cache_dir(tmp_path):
+    "deliver() returns paths under adaptor.cache_dir/<request_id>, not file:// URIs."
+    adaptor = _make_adaptor(tmp_path)
+
+    spec = ServiceXSpec(
+        General=General(),
+        Sample=[
+            Sample(
+                Name="test_me",
+                Dataset=dataset.FileList("test.root"),
+                Query="query1",
+            )
+        ],
+    )
+
+    r = deliver(spec, adaptor=adaptor)
+    assert r is not None
+    files = r["test_me"]
+    assert len(files) == 1
+
+    downloaded = Path(files[0])
+    assert downloaded.exists()
+    # The download must live under the per-request subdir of the adaptor's
+    # cache_dir, and it must be a real path (not a file:// URI string).
+    assert not str(downloaded).startswith("file://")
+    expected_dir = tmp_path / adaptor._request_id
+    assert downloaded.parent == expected_dir.resolve()

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -70,7 +70,7 @@ def test_find_dataset(fs, input_path, prefer_local, expected_local, fs_file):
     ],
 )
 def test_install_sx_local(monkeypatch, image, platform, expected_class):
-    codegen_name, adaptor = install_sx_local(image, platform)
+    adaptor = install_sx_local(image, platform)
     assert isinstance(adaptor.science_runner, expected_class)
 
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,5 +1,4 @@
 import getpass
-from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,3 +1,7 @@
+import getpass
+from pathlib import Path
+from unittest.mock import MagicMock
+
 import pytest
 from servicex_local import find_dataset, install_sx_local, Platform
 from servicex_local import DockerScienceImage, SingularityScienceImage, WSL2ScienceImage
@@ -77,3 +81,51 @@ def test_install_sx_local(monkeypatch, image, platform, expected_class):
 def test_install_sx_local_errors():
     with pytest.raises(ValueError, match="Unknown platform"):
         install_sx_local("some_image", platform="invalid_platform")
+
+
+def test_install_sx_local_uses_yaml_cache_path(monkeypatch, tmp_path):
+    "install_sx_local takes cache_path from servicex.yaml when one is found."
+    yaml_cache = tmp_path / "from_yaml"
+    yaml_cache.mkdir()
+
+    fake_cfg = MagicMock()
+    fake_cfg.cache_path = str(yaml_cache)
+    monkeypatch.setattr(
+        "servicex.configuration.Configuration.read",
+        classmethod(lambda cls: fake_cfg),
+    )
+
+    adaptor = install_sx_local(
+        "sslhep/servicex_func_adl_xaod_transformer:25.2.41", Platform.docker
+    )
+
+    assert adaptor.cache_dir == yaml_cache.resolve() / f"servicex_{getpass.getuser()}"
+
+
+def test_install_sx_local_no_yaml_fallback(monkeypatch):
+    """install_sx_local falls back to a usable cache dir when no
+    servicex.yaml is found.
+
+    Regression: the fallback used to assign cache_dir from inside a
+    ``with tempfile.TemporaryDirectory()`` block, leaving the path dangling
+    after the block exited.
+    """
+
+    def raise_nameerror(cls):
+        raise NameError("Can't find .servicex or servicex.yaml config file")
+
+    monkeypatch.setattr(
+        "servicex.configuration.Configuration.read",
+        classmethod(raise_nameerror),
+    )
+
+    adaptor = install_sx_local(
+        "sslhep/servicex_func_adl_xaod_transformer:25.2.41", Platform.docker
+    )
+
+    # The fallback must produce a cache_dir whose parent exists on disk so
+    # the adaptor can actually write into it.
+    assert adaptor.cache_dir.parent.exists(), (
+        f"Fallback cache_dir parent does not exist: {adaptor.cache_dir.parent}. "
+        "The TemporaryDirectory was likely cleaned up before being used."
+    )


### PR DESCRIPTION
This PR makes it so that SX_Local looks through the user files to see if there is a servicex.yaml. If one exists it uses the download location of that mimicking the behavior of ServiceX_Frontend.